### PR TITLE
Fix dependency conflicts in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-streamlit==1.35.0
+streamlit==1.37.0
 yfinance==0.2.40
-pandas==2.2.2
-pandas-ta==0.3.14b
+pandas==2.3.2
+pandas-ta==0.4.71b0
 plotly==5.23.0
 prophet==1.1.5
 requests==2.32.3


### PR DESCRIPTION
The application was failing with `ModuleNotFoundError: No module named 'yfinance'` due to a dependency conflict between `streamlit` and `pandas-ta`.

- `streamlit==1.35.0` required `numpy<2`
- `pandas-ta` (latest versions) required `numpy>=2.2.6`

This commit resolves the conflict by:
1. Upgrading `streamlit` to version `1.37.0`, which supports `numpy` 2.0.
2. Pinning `pandas-ta` to version `0.4.71b0`, which is compatible with the new `numpy`.
3. Pinning `pandas` to version `2.3.2` to satisfy the requirement of `pandas-ta`.

These changes ensure that all dependencies are compatible and can be installed successfully, resolving the `ModuleNotFoundError`.